### PR TITLE
Add request id in middleware

### DIFF
--- a/apps/example.json
+++ b/apps/example.json
@@ -22,8 +22,7 @@
           }]
         },
         "global_headers": {
-          "X-User-Email": "$tyk_meta.email",
-          "Tyk-Content-Request-ID": "$tyk_context.request_id"
+          "X-Request-Identifier": "$tyk_context.request_id"
         }
       }
     }

--- a/apps/example.json
+++ b/apps/example.json
@@ -22,7 +22,8 @@
           }]
         },
         "global_headers": {
-          "x-user-email": "$tyk_meta.email"
+          "X-User-Email": "$tyk_meta.email",
+          "Tyk-Content-Request-ID": "$tyk_context.request_id"
         }
       }
     }
@@ -39,5 +40,14 @@
     "enable_upstream_cache_control": true,
     "cache_response_codes": [200]
   },
-  "active": true
+  "active": true,
+  "custom_middleware": {
+    "post": [
+      {
+        "name": "request_id",
+        "path": "middleware/request_id.js",
+        "require_session": false
+      }
+    ]
+  }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ app:
     - ./policies.json:/opt/tyk-gateway/policies/policies.json
     - ./apps:/opt/tyk-gateway/apps
     - ./middleware:/opt/tyk-gateway/middleware
+    - ./js:/opt/tyk-gateway/js
   links:
     - redis
 

--- a/js/tyk.js
+++ b/js/tyk.js
@@ -1,0 +1,81 @@
+// ----- Tyk Middleware JS definition: this should be in the global context -----
+
+var TykJS = {
+        TykMiddleware: {
+            MiddlewareComponentMeta: function(configuration) {
+                this.configuration = configuration;
+            }
+        },
+        TykEventHandlers: {
+                EventHandlerComponentMeta: function() {}
+        }
+};
+
+TykJS.TykMiddleware.MiddlewareComponentMeta.prototype.ProcessRequest = function(request, session, config) {
+    log("Process Request Not Implemented");
+    return request;
+};
+
+TykJS.TykMiddleware.MiddlewareComponentMeta.prototype.DoProcessRequest = function(request, session, config) {
+    var processed_request = this.ProcessRequest(request, session, config);
+
+    if (!processed_request) {
+        log("Middleware didn't return request object!");
+        return;
+    }
+
+    // Reset the headers object
+    processed_request.Request.Headers = {}
+
+    return JSON.stringify(processed_request)
+};
+
+// The user-level middleware component
+TykJS.TykMiddleware.NewMiddleware = function(configuration) {
+    TykJS.TykMiddleware.MiddlewareComponentMeta.call(this, configuration);
+};
+
+// Set up object inheritance
+TykJS.TykMiddleware.NewMiddleware.prototype = Object.create(TykJS.TykMiddleware.MiddlewareComponentMeta.prototype);
+TykJS.TykMiddleware.NewMiddleware.prototype.constructor = TykJS.TykMiddleware.NewMiddleware;
+
+TykJS.TykMiddleware.NewMiddleware.prototype.NewProcessRequest = function(callback) {
+    this.ProcessRequest = callback;
+};
+
+TykJS.TykMiddleware.NewMiddleware.prototype.ReturnData = function(request, session) {
+    return {Request: request, SessionMeta: session}
+};
+
+TykJS.TykMiddleware.NewMiddleware.prototype.ReturnAuthData = function(request, session) {
+    return {Request: request, Session: session}
+};
+
+// ---- End middleware implementation for global context ----
+
+// -- Start Event Handler implementation ----
+
+TykJS.TykEventHandlers.EventHandlerComponentMeta.prototype.DoProcessEvent = function(event, context) {
+    // call the handler
+    log("Calling built - in handle")
+    this.Handle(event, context);
+    return
+};
+
+TykJS.TykEventHandlers.EventHandlerComponentMeta.prototype.Handle = function(request, context) {
+    log("Handler not implemented!");
+    return request;
+};
+
+// The user-level event handler component
+TykJS.TykEventHandlers.NewEventHandler = function() {
+    TykJS.TykEventHandlers.EventHandlerComponentMeta.call(this);
+};
+
+// Set up object inheritance for events
+TykJS.TykEventHandlers.NewEventHandler.prototype = Object.create(TykJS.TykEventHandlers.EventHandlerComponentMeta.prototype);
+TykJS.TykEventHandlers.NewEventHandler.prototype.constructor = TykJS.TykEventHandlers.NewEventHandler;
+
+TykJS.TykEventHandlers.NewEventHandler.prototype.NewHandler = function(callback) {
+    this.Handle = callback;
+};

--- a/middleware/request_id.js
+++ b/middleware/request_id.js
@@ -1,11 +1,10 @@
 var request_id = new TykJS.TykMiddleware.NewMiddleware({});
 
-// Initialise it with your functionality by passing a closure that accepts two objects
-// into the NewProcessRequest() function:
 request_id.NewProcessRequest(function(request, session) {
-
-  console.log("This middleware does nothing, but will print this to your terminal.")
-
-  // You MUST return both the request and session metadata
+  var tykContentRequestId = request.Headers["Tyk-Content-Request-Id"][0];
+  var requestId = request.Headers["Request-Id"];
+  if (requestId === undefined) {
+    request.SetHeaders["Request-Id"] = tykContentRequestId;
+  }
   return request_id.ReturnData(request, session.meta_data);
 });

--- a/middleware/request_id.js
+++ b/middleware/request_id.js
@@ -1,10 +1,10 @@
 var request_id = new TykJS.TykMiddleware.NewMiddleware({});
 
 request_id.NewProcessRequest(function(request, session) {
-  var tykContentRequestId = request.Headers["Tyk-Content-Request-Id"][0];
-  var requestId = request.Headers["Request-Id"];
+  var tykContentRequestId = request.Headers["X-Request-Identifier"][0];
+  var requestId = request.Headers["X-Correlation-Identifier"];
   if (requestId === undefined) {
-    request.SetHeaders["Request-Id"] = tykContentRequestId;
+    request.SetHeaders["X-Correlation-Identifier"] = tykContentRequestId;
   }
   return request_id.ReturnData(request, session.meta_data);
 });


### PR DESCRIPTION
A request now has a unique tyk-content-request-id which is truely unique
to every request.  There is also a request-id which you can pass
through.  If blank the request-id will default to the
tyk-content-request-id (as a generation method on the initial request).

Have had to add tyk.js, which is apparently not needed so should remove
this in the future. (see
https://github.com/TykTechnologies/tyk/commit/0f5ab6ce9500efb6845749f0abe5acdfaa25f2fd)